### PR TITLE
Add support for URL redirect to root of domain (`/`)

### DIFF
--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -46,6 +46,8 @@ jobs:
         run: tree -a _redirects
       - name: Show tree (_site)
         run: tree -a _site
+      - name: Show index.html
+        run: cat _site/index.html
       - name: Post-Run
         run: |
           ${{ inputs.post-run }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,14 @@ jobs:
       default_redirect: "http://www.d.com"
       post-run: bats ./tests/test_default_url.bats
 
+  test-default-redirect-url-root:
+    name: Default (Redirect URL, root)
+    uses: ./.github/workflows/test-reusable.yml
+    with:
+      urls_config: not_needed.yml
+      default_redirect: /some_root_path
+      post-run: echo
+
   test-default-message:
     name: Default (Message)
     uses: ./.github/workflows/test-reusable.yml

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The plugin will generate an HTML file per Collection document, with every possib
 </html>
 ```
 
-Allowing it to be reached at `https://<site>/link1`. It does the same for the `index.html` and `404.hml` (for `/` or non-existing path, respetively), which can also be redirects or plain strings (default is `Nothing here!`).
+Allowing it to be reached at `https://<site>/link1`. It does the same for the `index.html` and `404.hml` (for `/` or non-existing path, respetively), which can also be redirects (absolute or relative to the domain) or plain strings (default is `Nothing here!`).
 
 ### Action
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See [How it works](#how-it-works).
 |Input|Description|Default|Required|
 |-----|-----------|-------|:------:|
 |`urls_config`|<p>The path to a YAML file associating redirect keys to URLs, e.g.:</p><pre>---<br />test1: https://www.bookcity.ca/<br />test2: https://www.gladdaybookshop.com<br /></pre>|`.github/urls.yml`|no|
-|`default_redirect`|<p>Default behaviour for <code>/</code> or any 404, can be either:<br />  * a URL to redirect to<br />  * a message to display</p>|`Nothing here!`|no|
+|`default_redirect`|<p>Default behaviour for <code>/</code> or any 404, can be either:<br />  * a URL (absolute) to redirect to (e.g. <code>https://www.aol.com/</code>)<br />  * a URL (relative) to redirect to from the domain (e.g. <code>/blog</code>)<br />  * a message to display (e.g. <code>Nothing here!</code>)</p>|`Nothing here!`|no|
 
 <!--doc_end-->
 

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,9 @@ inputs:
   default_redirect:
     description: |
       Default behaviour for `/` or any 404, can be either:
-        * a URL to redirect to
-        * a message to display
+        * a URL (absolute) to redirect to (e.g. `https://www.aol.com/`)
+        * a URL (relative) to redirect to from the domain (e.g. `/blog`)
+        * a message to display (e.g. `Nothing here!`)
     required: false
     default: "Nothing here!"
 

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,10 @@ runs:
     #   Sets permalink key to 404.html as per GitHub docs
 
     - shell: bash
-      if: startsWith(inputs.default_redirect, 'http')
+      id: url_redirect
+      if: |
+        startsWith(inputs.default_redirect, 'http') ||
+        startsWith(inputs.default_redirect, '/')
       env:
         REDIRECT_URL: ${{ inputs.default_redirect }}
       run: |
@@ -99,7 +102,7 @@ runs:
     # * Generate a plain 404.html with the message
 
     - shell: bash
-      if: "!startsWith(inputs.default_redirect, 'http')"
+      if: steps.url_redirect.conclusion == 'skipped'
       env:
         MESSAGE: ${{ inputs.default_redirect }}
       run: |


### PR DESCRIPTION
This PR,
* Enables the `default_redirect` to be relative paths (starting with `/`) that will direct to from the domain root (`<domain>/<path>`)

Fixes #5 